### PR TITLE
fix for JPA initialization problem with entitymanager

### DIFF
--- a/core/src/main/java/com/devonfw/keywi/general/dataaccess/impl/JpaConfig.java
+++ b/core/src/main/java/com/devonfw/keywi/general/dataaccess/impl/JpaConfig.java
@@ -1,0 +1,24 @@
+package com.devonfw.keywi.general.dataaccess.impl;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.devonfw.module.jpa.dataaccess.api.JpaInitializer;
+
+/**
+ * Spring {@link Configuration} for JPA.
+ */
+@Configuration
+public class JpaConfig {
+
+  /**
+   * @return the {@link JpaInitializer} to register the {@link javax.persistence.EntityManager} and make
+   *         {@link com.devonfw.module.jpa.dataaccess.api.JpaHelper} functional.
+   */
+  @Bean
+  public JpaInitializer jpaInitializer() {
+
+    return new JpaInitializer();
+  }
+
+}


### PR DESCRIPTION
fix for problem found by @maciejmalecki 
```
While testing saving on key item, I found this as a result of “entity manager not initialized” exception thrown during eto to entity mapping.
 
public static <E> E asEntity(Ref<?, ? super E> reference, Class<E> entityClass) {
  return reference == null ? null : JpaEntityManagerAccess.getEntityManager().getReference(entityClass, reference.getId());
}
 
Where are we supposed to initialize this? In interceptor?
 
 
Caused by: java.lang.IllegalStateException: EntityManager has not yet been initialized!
               at com.devonfw.module.jpa.dataaccess.api.JpaEntityManagerAccess.getEntityManager(JpaEntityManagerAccess.java:38) ~[devon4j-jpa-basic-3.0.1.jar:3.0.1]
               at com.devonfw.module.jpa.dataaccess.api.JpaHelper.asEntity(JpaHelper.java:48) ~[devon4j-jpa-basic-3.0.1.jar:3.0.1]
               at com.devonfw.keywi.keymanagement.dataaccess.api.KeyItemEntity.setKeyListId(KeyItemEntity.java:69) ~[classes/:na]
               ... 153 common frames omitted
```